### PR TITLE
Fixed scale overflow

### DIFF
--- a/src/js/rSlider.js
+++ b/src/js/rSlider.js
@@ -151,7 +151,7 @@
 
 		var pieces = this.slider.querySelectorAll('span');
 
-		for (var i = 0, iLen = pieces.length; i < iLen; i++)
+		for (var i = 0, iLen = pieces.length - 1; i < iLen; i++)
 			pieces[i].style.width = this.step + 'px';
 
 		return this.setValues();


### PR DESCRIPTION
Last element in scale should always have width 0.

Last element in scale was assigned a width, which causes it to overflow onto the next line. Fixed by assigning width to only one before the last element.